### PR TITLE
Static POC of template editor, like a GUI IDE

### DIFF
--- a/editor-preview.html
+++ b/editor-preview.html
@@ -8,9 +8,24 @@
             <a class="flex items-center justify-center h-full w-16 bg-gray-900" href="#">
                 <svg class="h-10 w-10 fill-current text-white" xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24" role="img" aria-hidden="true" focusable="false"><path d="M20 10c0-5.51-4.49-10-10-10C4.48 0 0 4.49 0 10c0 5.52 4.48 10 10 10 5.51 0 10-4.48 10-10zM7.78 15.37L4.37 6.22c.55-.02 1.17-.08 1.17-.08.5-.06.44-1.13-.06-1.11 0 0-1.45.11-2.37.11-.18 0-.37 0-.58-.01C4.12 2.69 6.87 1.11 10 1.11c2.33 0 4.45.87 6.05 2.34-.68-.11-1.65.39-1.65 1.58 0 .74.45 1.36.9 2.1.35.61.55 1.36.55 2.46 0 1.49-1.4 5-1.4 5l-3.03-8.37c.54-.02.82-.17.82-.17.5-.05.44-1.25-.06-1.22 0 0-1.44.12-2.38.12-.87 0-2.33-.12-2.33-.12-.5-.03-.56 1.2-.06 1.22l.92.08 1.26 3.41zM17.41 10c.24-.64.74-1.87.43-4.25.7 1.29 1.05 2.71 1.05 4.25 0 3.29-1.73 6.24-4.4 7.78.97-2.59 1.94-5.2 2.92-7.78zM6.1 18.09C3.12 16.65 1.11 13.53 1.11 10c0-1.3.23-2.48.72-3.59C3.25 10.3 4.67 14.2 6.1 18.09zm4.03-6.63l2.58 6.98c-.86.29-1.76.45-2.71.45-.79 0-1.57-.11-2.29-.33.81-2.38 1.62-4.74 2.42-7.1z"></path></svg>
             </a>
+            <button type="button" aria-disabled="true" class="components-button editor-history__undo has-icon" aria-label="Undo">
+                <svg width="24" height="24"
+                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+                    <path d="M18.3 11.7c-.6-.6-1.4-.9-2.3-.9H6.7l2.9-3.3-1.1-1-4.5 5L8.5 16l1-1-2.7-2.7H16c.5 0 .9.2 1.3.5 1 1 1 3.4 1 4.5v.3h1.5v-.2c0-1.5 0-4.3-1.5-5.7z"></path>
+                </svg>
+            </button>
+            <button type="button" aria-disabled="true" class="components-button editor-history__redo has-icon" aria-label="Redo">
+                <svg width="24" height="24"
+                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+                    <path d="M15.6 6.5l-1.1 1 2.9 3.3H8c-.9 0-1.7.3-2.3.9-1.4 1.5-1.4 4.2-1.4 5.6v.2h1.5v-.3c0-1.1 0-3.5 1-4.5.3-.3.7-.5 1.3-.5h9.2L14.5 15l1.1 1.1 4.6-4.6-4.6-5z"></path>
+                </svg>
+            </button>
             <a href="index.html"  class="flex items-center h-12 px-4 text-sm">
                 <span>Builder</span>
             </a>
+            <a href="template-editor.html" class="flex items-center h-12 px-4 text-sm">
+                <span>Template Editor</span>
+            </button>
             <a href="editor-preview.html"  class="flex items-center h-12 px-4 text-sm">
                 <span class="font-semibold"s>Editor Preview</span>
             </a>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
             <a href="index.html"  class="flex items-center h-12 px-4 text-sm">
                 <span class="font-semibold">Builder</span>
             </a>
+            <a href="template-editor.html" class="flex items-center h-12 px-4 text-sm focus:outline-none font-semibold">
+                <span>Template Editor</span>
+            </button>
             <a href="editor-preview.html"  class="flex items-center h-12 px-4 text-sm">
                 <span>Editor Preview</span>
             </a>

--- a/index.html
+++ b/index.html
@@ -8,10 +8,22 @@
             <a class="flex items-center justify-center h-full w-16 bg-gray-900" href="#">
                 <svg class="h-10 w-10 fill-current text-white" xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24" role="img" aria-hidden="true" focusable="false"><path d="M20 10c0-5.51-4.49-10-10-10C4.48 0 0 4.49 0 10c0 5.52 4.48 10 10 10 5.51 0 10-4.48 10-10zM7.78 15.37L4.37 6.22c.55-.02 1.17-.08 1.17-.08.5-.06.44-1.13-.06-1.11 0 0-1.45.11-2.37.11-.18 0-.37 0-.58-.01C4.12 2.69 6.87 1.11 10 1.11c2.33 0 4.45.87 6.05 2.34-.68-.11-1.65.39-1.65 1.58 0 .74.45 1.36.9 2.1.35.61.55 1.36.55 2.46 0 1.49-1.4 5-1.4 5l-3.03-8.37c.54-.02.82-.17.82-.17.5-.05.44-1.25-.06-1.22 0 0-1.44.12-2.38.12-.87 0-2.33-.12-2.33-.12-.5-.03-.56 1.2-.06 1.22l.92.08 1.26 3.41zM17.41 10c.24-.64.74-1.87.43-4.25.7 1.29 1.05 2.71 1.05 4.25 0 3.29-1.73 6.24-4.4 7.78.97-2.59 1.94-5.2 2.92-7.78zM6.1 18.09C3.12 16.65 1.11 13.53 1.11 10c0-1.3.23-2.48.72-3.59C3.25 10.3 4.67 14.2 6.1 18.09zm4.03-6.63l2.58 6.98c-.86.29-1.76.45-2.71.45-.79 0-1.57-.11-2.29-.33.81-2.38 1.62-4.74 2.42-7.1z"></path></svg>
             </a>
+            <button type="button" aria-disabled="true" class="components-button editor-history__undo has-icon" aria-label="Undo">
+                <svg width="24" height="24"
+                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+                    <path d="M18.3 11.7c-.6-.6-1.4-.9-2.3-.9H6.7l2.9-3.3-1.1-1-4.5 5L8.5 16l1-1-2.7-2.7H16c.5 0 .9.2 1.3.5 1 1 1 3.4 1 4.5v.3h1.5v-.2c0-1.5 0-4.3-1.5-5.7z"></path>
+                </svg>
+            </button>
+            <button type="button" aria-disabled="true" class="components-button editor-history__redo has-icon" aria-label="Redo">
+                <svg width="24" height="24"
+                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+                    <path d="M15.6 6.5l-1.1 1 2.9 3.3H8c-.9 0-1.7.3-2.3.9-1.4 1.5-1.4 4.2-1.4 5.6v.2h1.5v-.3c0-1.1 0-3.5 1-4.5.3-.3.7-.5 1.3-.5h9.2L14.5 15l1.1 1.1 4.6-4.6-4.6-5z"></path>
+                </svg>
+            </button>
             <a href="index.html"  class="flex items-center h-12 px-4 text-sm">
                 <span class="font-semibold">Builder</span>
             </a>
-            <a href="template-editor.html" class="flex items-center h-12 px-4 text-sm focus:outline-none font-semibold">
+            <a href="template-editor.html" class="flex items-center h-12 px-4 text-sm">
                 <span>Template Editor</span>
             </button>
             <a href="editor-preview.html"  class="flex items-center h-12 px-4 text-sm">

--- a/template-editor.html
+++ b/template-editor.html
@@ -1,0 +1,176 @@
+<html>
+	<head>
+		<link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
+	</head>
+	<body class="sticky-menu">
+		<div class="clear">
+			<div class="h-screen flex flex-col items-center text-black">
+				<div class="flex items-center h-16 border-b border-gray-300 w-full">
+					<a class="flex items-center justify-center h-full w-16 bg-gray-900 text-white" href="edit.php?post_type=genesis_custom_block" aria-label="Go back to WordPress">
+						<svg
+							xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24" width="36" height="36" class="fill-current" role="img" aria-hidden="true" focusable="false">
+							<path d="M20 10c0-5.51-4.49-10-10-10C4.48 0 0 4.49 0 10c0 5.52 4.48 10 10 10 5.51 0 10-4.48 10-10zM7.78 15.37L4.37 6.22c.55-.02 1.17-.08 1.17-.08.5-.06.44-1.13-.06-1.11 0 0-1.45.11-2.37.11-.18 0-.37 0-.58-.01C4.12 2.69 6.87 1.11 10 1.11c2.33 0 4.45.87 6.05 2.34-.68-.11-1.65.39-1.65 1.58 0 .74.45 1.36.9 2.1.35.61.55 1.36.55 2.46 0 1.49-1.4 5-1.4 5l-3.03-8.37c.54-.02.82-.17.82-.17.5-.05.44-1.25-.06-1.22 0 0-1.44.12-2.38.12-.87 0-2.33-.12-2.33-.12-.5-.03-.56 1.2-.06 1.22l.92.08 1.26 3.41zM17.41 10c.24-.64.74-1.87.43-4.25.7 1.29 1.05 2.71 1.05 4.25 0 3.29-1.73 6.24-4.4 7.78.97-2.59 1.94-5.2 2.92-7.78zM6.1 18.09C3.12 16.65 1.11 13.53 1.11 10c0-1.3.23-2.48.72-3.59C3.25 10.3 4.67 14.2 6.1 18.09zm4.03-6.63l2.58 6.98c-.86.29-1.76.45-2.71.45-.79 0-1.57-.11-2.29-.33.81-2.38 1.62-4.74 2.42-7.1z"></path>
+						</svg>
+					</a>
+					<button type="button" aria-disabled="true" class="components-button editor-history__undo has-icon" aria-label="Undo">
+						<svg width="24" height="24"
+							xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+							<path d="M18.3 11.7c-.6-.6-1.4-.9-2.3-.9H6.7l2.9-3.3-1.1-1-4.5 5L8.5 16l1-1-2.7-2.7H16c.5 0 .9.2 1.3.5 1 1 1 3.4 1 4.5v.3h1.5v-.2c0-1.5 0-4.3-1.5-5.7z"></path>
+						</svg>
+					</button>
+					<button type="button" aria-disabled="true" class="components-button editor-history__redo has-icon" aria-label="Redo">
+						<svg width="24" height="24"
+							xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+							<path d="M15.6 6.5l-1.1 1 2.9 3.3H8c-.9 0-1.7.3-2.3.9-1.4 1.5-1.4 4.2-1.4 5.6v.2h1.5v-.3c0-1.1 0-3.5 1-4.5.3-.3.7-.5 1.3-.5h9.2L14.5 15l1.1 1.1 4.6-4.6-4.6-5z"></path>
+						</svg>
+					</button>
+					<a href="index.html" class="flex items-center h-12 px-4 text-sm focus:outline-none">
+						<span>Builder</span>
+					</a>
+					<button class="flex items-center h-12 px-4 text-sm focus:outline-none font-semibold">
+						<span>Template Editor</span>
+					</button>
+					<button class="flex items-center h-12 px-4 text-sm focus:outline-none">
+						<span>Editor Preview</span>
+					</button>
+					<button class="flex items-center h-12 px-4 text-sm focus:outline-none">
+						<span>Front-end Preview</span>
+					</button>
+				</div>
+				<div class="components-notice-list components-editor-notices__pinned"></div>
+				<div class="components-notice-list components-editor-notices__dismissible"></div>
+				<div class="components-snackbar-list components-editor-notices__snackbar"></div>
+				<div class="gcb-editor flex w-full h-0 flex-grow">
+					<div class="flex flex-col flex-grow items-start w-full overflow-scroll">
+						<div class="flex flex-col w-full max-w-2xl mx-auto pl-8 pr-8 pb-64">
+							<div class="text-4xl w-full mt-10 text-center focus:outline-none">
+								<div class="wp-block editor-post-title editor-post-title__block">
+									<label class="components-visually-hidden" for="post-title-0">Example Hero Block</label>
+								</div>
+							</div>
+							<div role="grid" class="grid grid-cols-4 gap-4 w-full items-start mt-2">
+								<div role="row" class="relative w-full rounded-sm border border-gray-400 hover:border-black col-span-4" tabindex="0" aria-label="Field: Testing Textarea">
+									<div role="gridcell" class="flex flex-col items-center w-full p-4 bg-white rounded-sm" id="field-item-0">
+										<div class="flex w-full items-center">
+											<div></div>
+											<span class=" ml-4 truncate">div</span>
+										</div>
+										<div role="grid" class="grid grid-cols-4 gap-4 w-full items-start mt-4">
+											<div role="row" class="relative w-full rounded-sm border border-gray-400 hover:border-black col-span-4" tabindex="0" aria-label="Field: New Field">
+												<div role="gridcell" class="flex flex-col items-center w-full p-4 bg-white rounded-sm" id="field-item-0">
+													<div class="flex w-full items-center">
+														<div></div>
+														<span class=" ml-4 truncate">h1</span>
+													</div>
+													<div class="clear"></div>
+													<!-- wpbody -->
+													<div class="clear"></div>
+													<!-- wpcontent -->
+												</div>
+											</div>
+											<div role="row" class="relative w-full rounded-sm border border-gray-400 hover:border-black col-span-4" tabindex="0" aria-label="Field: New Field">
+												<div role="gridcell" class="flex flex-col items-center w-full p-4 bg-white rounded-sm" id="field-item-0">
+													<div class="flex w-full items-center">
+														<div></div>
+														<span class=" ml-4 truncate">div</span>
+													</div>
+													<div role="grid" class="grid grid-cols-4 gap-4 w-full items-start mt-4">
+														<div role="row" style="outline: -webkit-focus-ring-color auto 1px" class="relative w-full rounded-sm border border-gray-400 hover:border-black col-span-4" tabindex="0" aria-label="Field: New Field">
+															<div role="gridcell" class="flex flex-col items-center w-full p-4 bg-white rounded-sm" id="field-item-0">
+																<div class="flex w-full items-center">
+																	<div></div>
+																	<span class=" ml-4 truncate">img</span>
+																	<div class="flex items-center h-6 pr-1 bg-gray-200 rounded-sm ml-auto hover:bg-gray-300">
+																		<button aria-label="Copy the field name of new-field"></button>
+																	</div>
+																</div>
+															</div>
+														</div>
+													</div>
+												</div>
+											</div>
+											<div role="row" class="relative w-full rounded-sm border border-gray-400 hover:border-black col-span-4" tabindex="0" aria-label="Field: New Field">
+												<div role="gridcell" class="flex flex-col items-center w-full p-4 bg-white rounded-sm" id="field-item-0">
+													<div class="flex w-full items-center">
+														<div></div>
+														<span class=" ml-4 truncate">div</span>
+													</div>
+													<div role="grid" class="grid grid-cols-4 gap-4 w-full items-start mt-4">
+														<div role="row" class="relative w-full rounded-sm border border-gray-400 hover:border-black col-span-4" tabindex="0" aria-label="Field: New Field">
+															<div role="gridcell" class="flex flex-col items-center w-full p-4 bg-white rounded-sm" id="field-item-0">
+																<div class="flex w-full items-center">
+																	<div></div>
+																	<span class=" ml-4 truncate">span</span>
+																	<div class="flex items-center h-6 pr-1 bg-gray-200 rounded-sm ml-auto hover:bg-gray-300">
+																		<button aria-label="Copy the field name of new-field"></button>
+																	</div>
+																</div>
+															</div>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="side flex-shrink-0 flex flex-col border-l border-gray-300 overflow-scroll">
+						<div class="flex flex-shrink-0 w-full border-b border-gray-300">
+							<button class="flex items-center h-12 px-5 text-sm focus:outline-none">Block</button>
+							<button class="flex items-center h-12 px-5 text-sm focus:outline-none font-semibold border-b-4 border-blue-600">Template</button>
+						</div>
+						<div class="p-4">
+							<h4 class="text-sm font-semibold">Block Settings</h4>
+							<div class="mt-5">
+								<label class="text-sm" for="block-categories">Tag</label>
+								<select class="flex items-center w-full h-8 rounded-sm border border-gray-600 mt-2 px-2 text-sm" id="block-categories">
+									<option value="text">img</option>
+									<option value="media">div</option>
+									<option value="design">span</option>
+									<option value="widgets">h1</option>
+									<option value="embed">h2</option>
+									<option value="reusable">h3</option>
+									<option value="text">h4</option>
+									<option value="SOME">h5</option>
+									<option value="media">ul</option>
+									<option value="theme">ol</option>
+									<option value="genesis-blocks">li</option>
+								</select>
+								<span class="block italic text-xs mt-1">Choose from any field you added in the 'Builder'</span>
+							</div>
+							<div class="mt-5">
+								<label class="text-sm" for="block-categories">src attribute</label>
+								<select class="flex items-center w-full h-8 rounded-sm border border-gray-600 mt-2 px-2 text-sm" id="block-categories">
+									<option value="text">hero-heading</option>
+									<option value="media">text</option>
+									<option value="design">docs</option>
+									<option value="widgets">docs-text</option>
+									<option value="embed">background-image</option>
+									<option value="reusable">buttons</option>
+									<option value="text">button-text</option>
+									<option value="SOME">button-url</option>
+								</select>
+								<span class="block italic text-xs mt-1">Choose from any field you added in the 'Builder'</span>
+							</div>
+							<div class="mt-5">
+								<label class="text-sm" for="block-categories">alt attribute</label>
+								<select class="flex items-center w-full h-8 rounded-sm border border-gray-600 mt-2 px-2 text-sm" id="block-categories">
+									<option value="text">hero-heading</option>
+									<option value="media">text</option>
+									<option value="design">docs</option>
+									<option value="widgets">docs-text</option>
+									<option value="embed">background-image</option>
+									<option value="reusable">buttons</option>
+									<option value="text">button-text</option>
+									<option value="SOME">button-url</option>
+								</select>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</body>
+</html>

--- a/template-editor.html
+++ b/template-editor.html
@@ -166,6 +166,7 @@
 									<option value="text">button-text</option>
 									<option value="SOME">button-url</option>
 								</select>
+								<span class="block italic text-xs mt-1">Choose from any field you added in the 'Builder'</span>
 							</div>
 						</div>
 					</div>

--- a/template-editor.html
+++ b/template-editor.html
@@ -30,9 +30,9 @@
 					<button class="flex items-center h-12 px-4 text-sm focus:outline-none font-semibold">
 						<span>Template Editor</span>
 					</button>
-					<button class="flex items-center h-12 px-4 text-sm focus:outline-none">
+					<a href="editor-preview.html" class="flex items-center h-12 px-4 text-sm focus:outline-none">
 						<span>Editor Preview</span>
-					</button>
+					</a>
 					<button class="flex items-center h-12 px-4 text-sm focus:outline-none">
 						<span>Front-end Preview</span>
 					</button>
@@ -143,28 +143,26 @@
 							<div class="mt-5">
 								<label class="text-sm" for="block-categories">src attribute</label>
 								<select class="flex items-center w-full h-8 rounded-sm border border-gray-600 mt-2 px-2 text-sm" id="block-categories">
-									<option value="text">hero-heading</option>
-									<option value="media">text</option>
-									<option value="design">docs</option>
-									<option value="widgets">docs-text</option>
-									<option value="embed">background-image</option>
-									<option value="reusable">buttons</option>
-									<option value="text">button-text</option>
-									<option value="SOME">button-url</option>
+									<option value="background-image">background-image</option>
+									<option value="hero-heading">hero-heading</option>
+									<option value="sub-heading">sub-heading</option>
+									<option value="text">text</option>
+									<option value="docs">docs</option>
+									<option value="docs-text">docs-text</option>
+									<option value="buttons">buttons</option>
 								</select>
 								<span class="block italic text-xs mt-1">Choose from any field you added in the 'Builder'</span>
 							</div>
 							<div class="mt-5">
 								<label class="text-sm" for="block-categories">alt attribute</label>
 								<select class="flex items-center w-full h-8 rounded-sm border border-gray-600 mt-2 px-2 text-sm" id="block-categories">
-									<option value="text">hero-heading</option>
-									<option value="media">text</option>
-									<option value="design">docs</option>
-									<option value="widgets">docs-text</option>
-									<option value="embed">background-image</option>
-									<option value="reusable">buttons</option>
-									<option value="text">button-text</option>
-									<option value="SOME">button-url</option>
+									<option value="text">text</option>
+									<option value="background-image">background-image</option>
+									<option value="hero-heading">hero-heading</option>
+									<option value="sub-heading">sub-heading</option>
+									<option value="docs">docs</option>
+									<option value="docs-text">docs-text</option>
+									<option value="buttons">buttons</option>
 								</select>
 								<span class="block italic text-xs mt-1">Choose from any field you added in the 'Builder'</span>
 							</div>


### PR DESCRIPTION
For context: [GF-2712](https://wpengine.atlassian.net/browse/GF-2712)

https://kienstra.github.io/react-ui/template-editor.html
![the-fields-here](https://user-images.githubusercontent.com/4063887/111920432-8a78f180-8a54-11eb-8a87-c25bc6f41567.gif)

This repo is forked from Rob and Luke's, and even the markup I added uses their styling.

## Testing Steps

1. Just go to https://kienstra.github.io/react-ui/template-editor.html
1. Otherwise, clone this repo anywhere, it's just static HTML
1. In your browser, go to `file:///path/to/react-ui/template-editor.html`